### PR TITLE
Supplement google oauth docs

### DIFF
--- a/PaperSorter/tasks/serve.py
+++ b/PaperSorter/tasks/serve.py
@@ -41,6 +41,7 @@ def main(config, host, port, debug, log_file, quiet):
     initialize_logging(task="serve", logfile=log_file, quiet=quiet)
 
     log.info(f"Starting web server on {host}:{port}")
+    log.info(f"Please verify that you have added http://{host}:{port}/callback as authorized redirect URIs in your OAuth app.")
 
     app = create_app(config)
 

--- a/SETTING_OAUTH.md
+++ b/SETTING_OAUTH.md
@@ -35,12 +35,12 @@ oauth:
 ### 2. Configure OAuth Consent Screen
 
 1. In the Google Cloud Console, go to "APIs & Services" > "OAuth consent screen"
-2. Choose "External" user type (unless you're using Google Workspace)
-3. Fill in the required information:
+2. Navigate to the "Audience" tab and choose "External" user type (unless you're using Google Workspace)
+3. Fill in the required information at the "Branding" tab: 
    - App name: PaperSorter
    - User support email: Your email
    - Developer contact information: Your email
-4. Add scopes: `openid`, `email`, `profile`
+4. Add the following non-sensitive scopes at the "Data Access" tab: `openid`, `email`, `profile`
 5. Save and continue
 
 ### 3. Create OAuth 2.0 Credentials


### PR DESCRIPTION
Slight supplements to assist in Google OAuth docs

1. Previously adding `localhost:5001` prevented accessing `0.0.0.0/5001` from working as only `localhost:5001` was authorized URI. 
2. Navigating and finding the necessary buttons for Google OAuth might be difficult when first using the program. 