### PR TITLE
DB Schema: Configurable embedding dimension with class-based schema

### DIFF
--- a/PaperSorter/data/schema.py
+++ b/PaperSorter/data/schema.py
@@ -23,239 +23,239 @@
 
 """Database schema definitions for PaperSorter."""
 
-# Custom types
-CUSTOM_TYPES = {
-    "preferences_source": {
-        "type": "ENUM",
-        "values": ["feed-star", "interactive", "alert-feedback"]
-    }
-}
+import dataclasses
 
-# Table definitions in dependency order
-TABLES = [
-    {
-        "name": "users",
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("username", "text NOT NULL UNIQUE"),
-            ("password", "text NOT NULL"),
-            ("created", "timestamp with time zone"),
-            ("lastlogin", "timestamp with time zone"),
-            ("is_admin", "boolean DEFAULT false NOT NULL"),
-            ("timezone", "text DEFAULT 'Asia/Seoul'"),
-            ("bookmark", "bigint"),
-            ("feedlist_minscore", "integer DEFAULT 25"),
-        ]
-    },
-    {
-        "name": "articles",  # Legacy compatibility
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("external_id", "text UNIQUE"),
-            ("title", "text NOT NULL"),
-            ("content", "text"),
-            ("author", "text"),
-            ("origin", "text"),
-            ("link", "text"),
-            ("mediaurl", "text"),
-            ("tldr", "text"),
-            ("published", "timestamp with time zone NOT NULL"),
-            ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
-        ]
-    },
-    {
-        "name": "feeds",  # Main table
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("external_id", "text UNIQUE"),
-            ("title", "text NOT NULL"),
-            ("content", "text"),
-            ("author", "text"),
-            ("origin", "text"),
-            ("link", "text"),
-            ("mediaurl", "text"),
-            ("tldr", "text"),
-            ("published", "timestamp with time zone NOT NULL"),
-            ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
-        ]
-    },
-    {
-        "name": "feed_sources",
-        "columns": [
-            ("id", "serial PRIMARY KEY"),
-            ("name", "text NOT NULL"),
-            ("source_type", "text NOT NULL"),
-            ("url", "text"),
-            ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
-            ("last_updated", "timestamp with time zone"),
-            ("last_checked", "timestamp with time zone"),
-        ]
-    },
-    {
-        "name": "models",
-        "columns": [
-            ("id", "serial PRIMARY KEY"),
-            ("user_id", "bigint REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
-            ("name", "text"),
-            ("created", "timestamp with time zone DEFAULT now() NOT NULL"),
-            ("is_active", "boolean DEFAULT true NOT NULL"),
-        ]
-    },
-    {
-        "name": "channels",
-        "columns": [
-            ("id", "serial PRIMARY KEY"),
-            ("name", "text"),
-            ("endpoint_url", "text"),
-            ("score_threshold", "double precision"),
-            ("model_id", "integer REFERENCES {schema}.models(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("is_active", "boolean DEFAULT true NOT NULL"),
-            ("broadcast_limit", "integer DEFAULT 20"),
-        ]
-    },
-    {
-        "name": "embeddings",
-        "columns": [
-            ("feed_id", "bigint PRIMARY KEY REFERENCES {schema}.feeds(id) ON DELETE CASCADE"),
-            ("embedding", "public.vector(1536)"),
-        ]
-    },
-    {
-        "name": "preferences",
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("feed_id", "integer NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("user_id", "bigint NOT NULL REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
-            ("time", "timestamp with time zone"),
-            ("score", "double precision"),
-            ("source", "{schema}.preferences_source NOT NULL"),
-        ]
-    },
-    {
-        "name": "predicted_preferences",
-        "columns": [
-            ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("model_id", "integer NOT NULL REFERENCES {schema}.models(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("score", "double precision NOT NULL"),
-        ],
-        "primary_key": ["feed_id", "model_id"]
-    },
-    {
-        "name": "broadcasts",
-        "columns": [
-            ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("channel_id", "integer NOT NULL REFERENCES {schema}.channels(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("broadcasted_time", "timestamp with time zone"),
-        ],
-        "primary_key": ["feed_id", "channel_id"]
-    },
-    {
-        "name": "labeling_sessions",
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
-            ("user_id", "bigint NOT NULL REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
-            ("score", "double precision"),
-            ("update_time", "timestamp with time zone"),
-        ]
-    },
-    {
-        "name": "events",
-        "columns": [
-            ("id", "serial PRIMARY KEY"),
-            ("occurred", "timestamp with time zone DEFAULT now() NOT NULL"),
-            ("event_type", "text"),
-            ("external_id", "text"),
-            ("content", "text"),
-            ("feed_id", "bigint REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("user_id", "integer REFERENCES {schema}.users(id) ON UPDATE CASCADE"),
-        ]
-    },
-    {
-        "name": "saved_searches",
-        "columns": [
-            ("id", "bigserial PRIMARY KEY"),
-            ("short_name", "text NOT NULL UNIQUE"),
-            ("user_id", "integer REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE CASCADE"),
-            ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
-            ("query", "text NOT NULL UNIQUE"),
-            ("last_access", "timestamp with time zone"),
-        ]
-    },
-    {
-        "name": "migrtmp_rss_dup_check",
-        "columns": [
-            ("external_id", "text PRIMARY KEY"),
-            ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
-        ]
-    },
-]
+@dataclasses.dataclass
+class Schema:
+    def __init__(self, embedding_dimensions):
+        self.CUSTOM_TYPES = {
+            "preferences_source": {
+                "type": "ENUM",
+                "values": ["feed-star", "interactive", "alert-feedback"]
+            }
+        }
 
-# Index definitions
-INDEXES = [
-    # HNSW index for vector similarity search
-    {
-        "name": "embeddings_embedding_idx",
-        "table": "embeddings",
-        "type": "hnsw",
-        "columns": ["embedding public.vector_cosine_ops"],
-    },
+        self.TABLES = [
+            {
+                "name": "users",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),
+                    ("username", "text NOT NULL UNIQUE"),
+                    ("password", "text NOT NULL"),
+                    ("created", "timestamp with time zone"),
+                    ("lastlogin", "timestamp with time zone"),
+                    ("is_admin", "boolean DEFAULT false NOT NULL"),
+                    ("timezone", "text DEFAULT 'Asia/Seoul'"),
+                    ("bookmark", "bigint"),
+                    ("feedlist_minscore", "integer DEFAULT 25"),
+                ]
+            },
+            {
+                "name": "articles",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),
+                    ("external_id", "text UNIQUE"),
+                    ("title", "text NOT NULL"),
+                    ("content", "text"),
+                    ("author", "text"),
+                    ("origin", "text"),
+                    ("link", "text"),
+                    ("mediaurl", "text"),
+                    ("tldr", "text"),
+                    ("published", "timestamp with time zone NOT NULL"),
+                    ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
+                ]
+            },
+            {
+                "name": "feeds",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),    
+                    ("external_id", "text UNIQUE"),
+                    ("title", "text NOT NULL"),
+                    ("content", "text"),
+                    ("author", "text"),
+                    ("origin", "text"),
+                    ("link", "text"),   
+                    ("mediaurl", "text"),
+                    ("tldr", "text"),
+                    ("published", "timestamp with time zone NOT NULL"),
+                    ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
+                ]
+            },  
+            {
+                "name": "feed_sources",
+                "columns": [
+                    ("id", "serial PRIMARY KEY"),
+                    ("name", "text NOT NULL"),
+                    ("source_type", "text NOT NULL"),  
+                    ("url", "text"),
+                    ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
+                    ("last_updated", "timestamp with time zone"),
+                    ("last_checked", "timestamp with time zone"),
+                ]
+            },
+            {
+                "name": "models",
+                "columns": [
+                    ("id", "serial PRIMARY KEY"),
+                    ("user_id", "bigint REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
+                    ("name", "text"),
+                    ("created", "timestamp with time zone DEFAULT now() NOT NULL"),
+                    ("is_active", "boolean DEFAULT true NOT NULL"),
+                ]
+            },
+            {
+                "name": "channels",
+                "columns": [
+                    ("id", "serial PRIMARY KEY"),
+                    ("name", "text"),
+                    ("endpoint_url", "text"),
+                    ("score_threshold", "double precision"),
+                    ("model_id", "integer"),
+                    ("is_active", "boolean DEFAULT true NOT NULL"),
+                ]
+            },
+            {
+                "name": "embeddings",
+                "columns": [
+                    ("feed_id", "bigint PRIMARY KEY REFERENCES {schema}.feeds(id) ON DELETE CASCADE"),
+                    ("embedding", f"public.vector({embedding_dimensions})"),
+                ]
+            },
+            {
+                "name": "preferences",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),
+                    ("feed_id", "integer NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("user_id", "bigint NOT NULL REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
+                    ("time", "timestamp with time zone"),
+                    ("score", "double precision"),
+                    ("source", "{schema}.preferences_source NOT NULL"),
+                ]
+            },
+            {
+                "name": "predicted_preferences",
+                "columns": [
+                    ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("model_id", "integer NOT NULL REFERENCES {schema}.models(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("score", "double precision NOT NULL"),
+                ],
+                "primary_key": ["feed_id", "model_id"]
+            },
+            {
+                "name": "broadcasts",
+                "columns": [
+                    ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("channel_id", "integer NOT NULL REFERENCES {schema}.channels(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("broadcasted_time", "timestamp with time zone"),
+                ],
+                "primary_key": ["feed_id", "channel_id"]
+            },
+            {
+                "name": "labeling_sessions",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),
+                    ("feed_id", "bigint NOT NULL REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
+                    ("user_id", "bigint NOT NULL REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE RESTRICT"),
+                    ("score", "double precision"),
+                    ("update_time", "timestamp with time zone"),
+                ]
+            },
+            {
+                "name": "events",
+                "columns": [
+                    ("id", "serial PRIMARY KEY"),
+                    ("occurred", "timestamp with time zone DEFAULT now() NOT NULL"),
+                    ("event_type", "text"),
+                    ("external_id", "text"),
+                    ("content", "text"),
+                    ("feed_id", "bigint REFERENCES {schema}.feeds(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("user_id", "integer REFERENCES {schema}.users(id) ON UPDATE CASCADE"),
+                ]
+            },
+            {
+                "name": "saved_searches",
+                "columns": [
+                    ("id", "bigserial PRIMARY KEY"),
+                    ("short_name", "text NOT NULL UNIQUE"),
+                    ("user_id", "integer REFERENCES {schema}.users(id) ON UPDATE CASCADE ON DELETE CASCADE"),
+                    ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
+                    ("query", "text NOT NULL UNIQUE"),
+                    ("last_access", "timestamp with time zone"),
+                ]
+            },
+            {
+                "name": "migrtmp_rss_dup_check",
+                "columns": [
+                    ("external_id", "text PRIMARY KEY"),
+                    ("added", "timestamp with time zone DEFAULT now() NOT NULL"),
+                ]
+            },
+        ]
 
-    # Feeds indexes
-    {"name": "idx_feeds_external_id", "table": "feeds", "columns": ["external_id"]},
-    {"name": "idx_feeds_added", "table": "feeds", "columns": ["added"]},
-    {"name": "idx_feeds_published", "table": "feeds", "columns": ["published"]},
-    {"name": "idx_feeds_title", "table": "feeds", "columns": ["title"]},
-    {"name": "idx_feeds_link", "table": "feeds", "columns": ["link"]},
-    {"name": "idx_feeds_mediaurl", "table": "feeds", "columns": ["mediaurl"]},
+        self.INDEXES =    [
+             # HNSW index for vector similarity search
+            {
+                "name": "embeddings_embedding_idx",
+                "table": "embeddings",
+                "type": "hnsw",
+                "columns": ["embedding public.vector_cosine_ops"],
+            },
 
-    # Articles indexes (legacy compatibility)
-    {"name": "idx_articles_external_id", "table": "articles", "columns": ["external_id"]},
-    {"name": "idx_articles_added", "table": "articles", "columns": ["added"]},
-    {"name": "idx_articles_published", "table": "articles", "columns": ["published"]},
-    {"name": "idx_articles_title", "table": "articles", "columns": ["title"]},
-    {"name": "idx_articles_link", "table": "articles", "columns": ["link"]},
-    {"name": "idx_articles_mediaurl", "table": "articles", "columns": ["mediaurl"]},
+            # Feeds indexes
+            {"name": "idx_feeds_external_id", "table": "feeds", "columns": ["external_id"]},
+            {"name": "idx_feeds_added", "table": "feeds", "columns": ["added"]},
+            {"name": "idx_feeds_published", "table": "feeds", "columns": ["published"]},
+            {"name": "idx_feeds_title", "table": "feeds", "columns": ["title"]},
+            {"name": "idx_feeds_link", "table": "feeds", "columns": ["link"]},
+            {"name": "idx_feeds_mediaurl", "table": "feeds", "columns": ["mediaurl"]},
 
-    # Preferences indexes
-    {"name": "idx_preferences_feed_id", "table": "preferences", "columns": ["feed_id"]},
-    {"name": "idx_preferences_user_id", "table": "preferences", "columns": ["user_id"]},
-    {"name": "idx_preferences_score", "table": "preferences", "columns": ["score"]},
-    {"name": "idx_preferences_time", "table": "preferences", "columns": ["time"]},
+            # Articles indexes (legacy compatibility)
+            {"name": "idx_articles_external_id", "table": "articles", "columns": ["external_id"]},
+            {"name": "idx_articles_added", "table": "articles", "columns": ["added"]},
+            {"name": "idx_articles_published", "table": "articles", "columns": ["published"]},
+            {"name": "idx_articles_title", "table": "articles", "columns": ["title"]},
+            {"name": "idx_articles_link", "table": "articles", "columns": ["link"]},
+            {"name": "idx_articles_mediaurl", "table": "articles", "columns": ["mediaurl"]},
 
-    # Events indexes
-    {"name": "idx_events_occurred", "table": "events", "columns": ["occurred"]},
-    {"name": "idx_events_type", "table": "events", "columns": ["event_type"]},
-    {"name": "idx_events_feed", "table": "events", "columns": ["feed_id"]},
+            # Preferences indexes
+            {"name": "idx_preferences_feed_id", "table": "preferences", "columns": ["feed_id"]},
+            {"name": "idx_preferences_user_id", "table": "preferences", "columns": ["user_id"]},
+            {"name": "idx_preferences_score", "table": "preferences", "columns": ["score"]},
+            {"name": "idx_preferences_time", "table": "preferences", "columns": ["time"]},
 
-    # Broadcasts indexes
-    {"name": "idx_broadcasts_time", "table": "broadcasts", "columns": ["broadcasted_time"]},
+            # Events indexes
+            {"name": "idx_events_occurred", "table": "events", "columns": ["occurred"]},
+            {"name": "idx_events_type", "table": "events", "columns": ["event_type"]},
+            {"name": "idx_events_feed", "table": "events", "columns": ["feed_id"]},
 
-    # Feed sources indexes
-    {"name": "idx_feed_sources_last_checked", "table": "feed_sources", "columns": ["last_checked"]},
+            # Broadcasts indexes
+            {"name": "idx_broadcasts_time", "table": "broadcasts", "columns": ["broadcasted_time"]},
 
-    # Labeling sessions indexes
-    {"name": "idx_labeling_sessions_user", "table": "labeling_sessions", "columns": ["user_id"]},
-    {"name": "idx_labeling_sessions_score", "table": "labeling_sessions", "columns": ["user_id", "score"]},
+            # Feed sources indexes
+            {"name": "idx_feed_sources_last_checked", "table": "feed_sources", "columns": ["last_checked"]},
 
-    # Models indexes
-    {"name": "idx_models_user", "table": "models", "columns": ["user_id"]},
-]
+            # Labeling sessions indexes
+            {"name": "idx_labeling_sessions_user", "table": "labeling_sessions", "columns": ["user_id"]},
+            {"name": "idx_labeling_sessions_score", "table": "labeling_sessions", "columns": ["user_id", "score"]},
 
-# Tables to drop in reverse dependency order (for drop_existing option)
-DROP_ORDER = [
-    "embeddings",
-    "broadcasts",
-    "predicted_preferences",
-    "preferences",
-    "labeling_sessions",
-    "events",
-    "saved_searches",
-    "channels",
-    "models",
-    "feed_sources",
-    "feeds",
-    "articles",
-    "users",
-    "migrtmp_rss_dup_check",
-]
+            # Models indexes
+            {"name": "idx_models_user", "table": "models", "columns": ["user_id"]},
+        ]
+
+        self.DROP_ORDER = [
+            "embeddings",
+            "broadcasts",
+            "predicted_preferences",
+            "preferences",
+            "labeling_sessions",
+            "events",
+            "saved_searches",
+            "channels",
+            "models",
+            "feed_sources",
+            "feeds",
+            "articles",
+            "users",
+            "migrtmp_rss_dup_check",
+        ]

--- a/PaperSorter/tasks/init.py
+++ b/PaperSorter/tasks/init.py
@@ -25,7 +25,7 @@ import click
 import psycopg2
 import yaml
 from ..log import log
-from ..data import schema as db_schema
+from ..data.schema import Schema
 
 
 @click.option("--config", "-c", default="./config.yml", help="Config file")
@@ -43,6 +43,9 @@ def main(config, schema, drop_existing, quiet):
         cfg = yaml.safe_load(f)
 
     db_config = cfg["db"]
+    
+    # Get embedding dimensions from config
+    db_schema = Schema(cfg.get("embedding_api", {}).get("dimensions", 1536))
 
     # Connect to PostgreSQL
     conn = psycopg2.connect(


### PR DESCRIPTION
## Summary
- Previously, embedding dimension was hardcoded as 1536. 
- Refactor schema definitions into a `Schema` class 
- make the embeddings vector dimension configurable from `config.yml`. 
- Change `init` to use new `Schema` class

**Changes**
- Files: `PaperSorter/data/schema.py`, `PaperSorter/tasks/init.py`